### PR TITLE
Add Java CLI to search books by authors

### DIFF
--- a/authors-to-check.txt
+++ b/authors-to-check.txt
@@ -1,0 +1,2 @@
+Jane Austen
+Mark Twain

--- a/pom.xml
+++ b/pom.xml
@@ -10,4 +10,12 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.16.1</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/bc/bfi/AuthorsBooksFinder.java
+++ b/src/main/java/bc/bfi/AuthorsBooksFinder.java
@@ -1,0 +1,72 @@
+package bc.bfi;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AuthorsBooksFinder {
+    private static final String OPEN_LIBRARY_URL = "https://openlibrary.org/search.json?author=";
+
+    public static void main(String[] args) throws IOException {
+        List<String> authors = Files.readAllLines(Paths.get("authors-to-check.txt"), StandardCharsets.UTF_8)
+                .stream()
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+
+        if (authors.isEmpty()) {
+            System.out.println("No authors found in authors-to-check.txt");
+            return;
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        for (String author : authors) {
+            System.out.println("Author: " + author);
+            try {
+                String query = OPEN_LIBRARY_URL + URLEncoder.encode(author, "UTF-8");
+                HttpURLConnection connection = (HttpURLConnection) new URL(query).openConnection();
+                connection.setRequestMethod("GET");
+                connection.setConnectTimeout(10000);
+                connection.setReadTimeout(10000);
+
+                int status = connection.getResponseCode();
+                InputStream responseStream = (status >= 200 && status < 300)
+                        ? connection.getInputStream()
+                        : connection.getErrorStream();
+
+                String response = new BufferedReader(new InputStreamReader(responseStream, StandardCharsets.UTF_8))
+                        .lines()
+                        .collect(Collectors.joining("\n"));
+                connection.disconnect();
+
+                JsonNode root = mapper.readTree(response);
+                JsonNode docs = root.path("docs");
+                if (!docs.isArray() || docs.size() == 0) {
+                    System.out.println("  No books found.");
+                } else {
+                    int count = Math.min(3, docs.size());
+                    for (int i = 0; i < count; i++) {
+                        JsonNode doc = docs.get(i);
+                        String title = doc.path("title").asText("");
+                        System.out.println("  - " + title);
+                    }
+                }
+            } catch (Exception e) {
+                System.out.println("  Error retrieving books: " + e.getMessage());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Convert HTML/JS bulk author search into a Java console app
- Fetch up to three books per author from OpenLibrary and print titles
- Manage dependencies with Jackson JSON library

## Testing
- `mvn -q package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*
- `java -Djava.net.preferIPv4Stack=true -cp target/classes:lib/jackson-databind-2.16.1.jar:lib/jackson-core-2.16.1.jar:lib/jackson-annotations-2.16.1.jar bc.bfi.AuthorsBooksFinder` *(fails: Error retrieving books: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68bf7910cfb4832babcf3e6c9a344ef8