### PR TITLE
Fix incorrect Apache HttpClient imports

### DIFF
--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
@@ -17,8 +17,8 @@ import javax.json.JsonObject;
 import javax.json.JsonReader;
 
 import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.client5.http.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.io.entity.EntityUtils;


### PR DESCRIPTION
## Summary
- fix compile failure by importing CloseableHttpClient and CloseableHttpResponse from the correct Apache HttpClient package

## Testing
- `mvn -q -e -DskipTests compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68bf8d165c2c832b9252ef85bfd539ff