### PR TITLE
Handle ParseException in HTTP response

### DIFF
--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
@@ -109,7 +109,14 @@ public class Main {
             try {
                 final int status = response.getCode();
                 assert status == 200 : "Unexpected HTTP status: " + status;
-                final String body = EntityUtils.toString(response.getEntity(), "UTF-8");
+
+                final String body;
+                try {
+                    body = EntityUtils.toString(response.getEntity(), "UTF-8");
+                } catch (org.apache.hc.core5.http.ParseException ex) {
+                    throw new IOException("Failed to parse response entity", ex);
+                }
+
                 final JsonReader reader = Json.createReader(new StringReader(body));
                 try {
                     return reader.readObject();


### PR DESCRIPTION
## Summary
- catch and wrap entity parsing errors from Apache HttpClient to avoid unchecked ParseException

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68bf8ecc09d0832ba39c456260f4cb0b