### PR TITLE
Save author search results to MySQL

### DIFF
--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/AuthorRecord.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/AuthorRecord.java
@@ -1,0 +1,115 @@
+package bc.bfi.chatgpt_authors_books_finder;
+
+import java.util.Objects;
+
+public class AuthorRecord {
+
+    private final String position;
+    private final String author;
+    private final String title;
+    private final String url;
+    private final String snippet;
+    private final String isExactMatch;
+    private final String aiVerified;
+    private final String success;
+    private final String totalResults;
+    private final String processingTimeMs;
+    private final String aiUsed;
+    private final String searchEngine;
+    private final String filtersApplied;
+    private final String timestamp;
+    private final String domainCountry;
+
+    public AuthorRecord(
+            final String position,
+            final String author,
+            final String title,
+            final String url,
+            final String snippet,
+            final String isExactMatch,
+            final String aiVerified,
+            final String success,
+            final String totalResults,
+            final String processingTimeMs,
+            final String aiUsed,
+            final String searchEngine,
+            final String filtersApplied,
+            final String timestamp,
+            final String domainCountry) {
+        this.position = Objects.requireNonNull(position, "position");
+        this.author = Objects.requireNonNull(author, "author");
+        this.title = Objects.requireNonNull(title, "title");
+        this.url = Objects.requireNonNull(url, "url");
+        this.snippet = Objects.requireNonNull(snippet, "snippet");
+        this.isExactMatch = Objects.requireNonNull(isExactMatch, "isExactMatch");
+        this.aiVerified = Objects.requireNonNull(aiVerified, "aiVerified");
+        this.success = Objects.requireNonNull(success, "success");
+        this.totalResults = Objects.requireNonNull(totalResults, "totalResults");
+        this.processingTimeMs = Objects.requireNonNull(processingTimeMs, "processingTimeMs");
+        this.aiUsed = Objects.requireNonNull(aiUsed, "aiUsed");
+        this.searchEngine = Objects.requireNonNull(searchEngine, "searchEngine");
+        this.filtersApplied = Objects.requireNonNull(filtersApplied, "filtersApplied");
+        this.timestamp = Objects.requireNonNull(timestamp, "timestamp");
+        this.domainCountry = Objects.requireNonNull(domainCountry, "domainCountry");
+    }
+
+    public String getPosition() {
+        return position;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getSnippet() {
+        return snippet;
+    }
+
+    public String getIsExactMatch() {
+        return isExactMatch;
+    }
+
+    public String getAiVerified() {
+        return aiVerified;
+    }
+
+    public String getSuccess() {
+        return success;
+    }
+
+    public String getTotalResults() {
+        return totalResults;
+    }
+
+    public String getProcessingTimeMs() {
+        return processingTimeMs;
+    }
+
+    public String getAiUsed() {
+        return aiUsed;
+    }
+
+    public String getSearchEngine() {
+        return searchEngine;
+    }
+
+    public String getFiltersApplied() {
+        return filtersApplied;
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public String getDomainCountry() {
+        return domainCountry;
+    }
+}

--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Base.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Base.java
@@ -5,9 +5,9 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.Objects;
 
 public class Base {
 
@@ -31,7 +31,7 @@ public class Base {
     /**
      * Constructor for tests which allows to inject connection instance.
      */
-    Base(Connection connection) {
+    Base(final Connection connection) {
         this.connection = connection;
     }
 
@@ -51,42 +51,45 @@ public class Base {
         }
     }
 
-    void add(ChannelAbout channel) {
-        if (channel == null) {
-            return;
-        }
+    void add(final AuthorRecord record) {
+        Objects.requireNonNull(record, "record");
 
         try {
             connect();
 
-            String sql = "INSERT INTO " + DB_TABLE
-                    + "(url, description, videos, views, join_date, link_to_instagram, link_to_facebook, link_to_twitter, link_to_tiktok, other_links, verification, thumbnail)"
-                    + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+            final String sql = "INSERT INTO " + DB_TABLE
+                    + "(position, author, title, url, snippet, is_exact_match, ai_verified, success, total_results, processing_time_ms, ai_used, search_engine, filters_applied, timestamp, domain_country)"
+                    + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
             try (PreparedStatement stmt = connection.prepareStatement(sql)) {
-                stmt.setString(1, channel.getUrl());
-                stmt.setString(2, channel.getDescription());
-                stmt.setString(3, channel.getVideosAsNumber());
-                stmt.setString(4, channel.getViewsAsNumber());
-                stmt.setString(5, channel.getJoinDate());
-                stmt.setString(6, channel.getLinkToInstagram());
-                stmt.setString(7, channel.getLinkToFacebook());
-                stmt.setString(8, channel.getLinkToTwitter());
-                stmt.setString(9, channel.getLinkToTiktok());
-                stmt.setString(10, channel.getOtherLinks());
-                stmt.setString(11, channel.getVerification());
-                stmt.setString(12, channel.getThumbnail());
+                stmt.setString(1, record.getPosition());
+                stmt.setString(2, record.getAuthor());
+                stmt.setString(3, record.getTitle());
+                stmt.setString(4, record.getUrl());
+                stmt.setString(5, record.getSnippet());
+                stmt.setString(6, record.getIsExactMatch());
+                stmt.setString(7, record.getAiVerified());
+                stmt.setString(8, record.getSuccess());
+                stmt.setString(9, record.getTotalResults());
+                stmt.setString(10, record.getProcessingTimeMs());
+                stmt.setString(11, record.getAiUsed());
+                stmt.setString(12, record.getSearchEngine());
+                stmt.setString(13, record.getFiltersApplied());
+                stmt.setString(14, record.getTimestamp());
+                stmt.setString(15, record.getDomainCountry());
 
                 stmt.executeUpdate();
             } catch (SQLIntegrityConstraintViolationException ex) {
-                LOGGER.log(Level.WARNING, "Skip duplicate URL in database: " + channel.getUrl(), ex);
+                LOGGER.log(Level.WARNING, "Skip duplicate URL in database: " + record.getUrl(), ex);
             }
         } catch (SQLException ex) {
             LOGGER.log(Level.SEVERE, ex.getMessage(), ex);
         }
     }
 
-    boolean exists(String url) {
+    boolean exists(final String url) {
+        Objects.requireNonNull(url, "url");
+
         boolean found = false;
 
         try {

--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
@@ -51,16 +51,21 @@ public class Main {
             baseUrl = "http://localhost:3000";
         }
 
-        for (int i = 0; i < authors.size(); i++) {
-            final String author = authors.get(i);
-            System.out.println("Processing author: " + author);
-            try {
-                final JsonObject data = searchAuthor(baseUrl, author);
-                handleAuthorResult(author, data);
-            } catch (IOException ex) {
-                System.out.println("Failed to search: " + ex.getMessage());
+        final Base base = new Base();
+        try {
+            for (int i = 0; i < authors.size(); i++) {
+                final String author = authors.get(i);
+                System.out.println("Processing author: " + author);
+                try {
+                    final JsonObject data = searchAuthor(baseUrl, author);
+                    handleAuthorResult(author, data, base);
+                } catch (IOException ex) {
+                    System.out.println("Failed to search: " + ex.getMessage());
+                }
+                System.out.println();
             }
-            System.out.println();
+        } finally {
+            base.close();
         }
     }
 
@@ -131,9 +136,10 @@ public class Main {
         }
     }
 
-    private static void handleAuthorResult(final String author, final JsonObject data) {
+    private static void handleAuthorResult(final String author, final JsonObject data, final Base base) {
         Objects.requireNonNull(author, "author");
         Objects.requireNonNull(data, "data");
+        Objects.requireNonNull(base, "base");
 
         final JsonArray results;
         if (data.containsKey("results")) {
@@ -234,6 +240,24 @@ public class Main {
             System.out.println("Filters Applied: " + filtersApplied);
             System.out.println("Timestamp: " + timestamp);
             System.out.println("---");
+
+            final AuthorRecord record = new AuthorRecord(
+                    String.valueOf(position),
+                    author,
+                    title,
+                    url,
+                    snippet,
+                    isExact,
+                    aiVerified,
+                    String.valueOf(success),
+                    String.valueOf(totalResults),
+                    String.valueOf(processingTime),
+                    String.valueOf(aiUsed),
+                    searchEngine,
+                    filtersApplied,
+                    timestamp,
+                    domainCountry);
+            base.add(record);
         }
     }
 


### PR DESCRIPTION
## Summary
- add AuthorRecord model to represent scraped author search entries
- extend Base to insert author records into the `authors` table
- persist search results via Base from Main after each lookup

## Testing
- ⚠️ `mvn -q -e test` *(failed: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68bf932490cc832bac090f4611d37cdd