### PR TITLE
Store and display domain for authors

### DIFF
--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/AuthorRecord.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/AuthorRecord.java
@@ -8,6 +8,7 @@ public class AuthorRecord {
     private final String author;
     private final String title;
     private final String url;
+    private final String domain;
     private final String snippet;
     private final String isExactMatch;
     private final String aiVerified;
@@ -25,6 +26,7 @@ public class AuthorRecord {
             final String author,
             final String title,
             final String url,
+            final String domain,
             final String snippet,
             final String isExactMatch,
             final String aiVerified,
@@ -40,6 +42,7 @@ public class AuthorRecord {
         this.author = Objects.requireNonNull(author, "author");
         this.title = Objects.requireNonNull(title, "title");
         this.url = Objects.requireNonNull(url, "url");
+        this.domain = Objects.requireNonNull(domain, "domain");
         this.snippet = Objects.requireNonNull(snippet, "snippet");
         this.isExactMatch = Objects.requireNonNull(isExactMatch, "isExactMatch");
         this.aiVerified = Objects.requireNonNull(aiVerified, "aiVerified");
@@ -67,6 +70,10 @@ public class AuthorRecord {
 
     public String getUrl() {
         return url;
+    }
+
+    public String getDomain() {
+        return domain;
     }
 
     public String getSnippet() {

--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Base.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Base.java
@@ -58,25 +58,26 @@ public class Base {
             connect();
 
             final String sql = "INSERT INTO " + DB_TABLE
-                    + "(position, author, title, url, snippet, is_exact_match, ai_verified, success, total_results, processing_time_ms, ai_used, search_engine, filters_applied, timestamp, domain_country)"
-                    + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                    + "(position, author, title, url, domain, snippet, is_exact_match, ai_verified, success, total_results, processing_time_ms, ai_used, search_engine, filters_applied, timestamp, domain_country)"
+                    + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
             try (PreparedStatement stmt = connection.prepareStatement(sql)) {
                 stmt.setString(1, record.getPosition());
                 stmt.setString(2, record.getAuthor());
                 stmt.setString(3, record.getTitle());
                 stmt.setString(4, record.getUrl());
-                stmt.setString(5, record.getSnippet());
-                stmt.setString(6, record.getIsExactMatch());
-                stmt.setString(7, record.getAiVerified());
-                stmt.setString(8, record.getSuccess());
-                stmt.setString(9, record.getTotalResults());
-                stmt.setString(10, record.getProcessingTimeMs());
-                stmt.setString(11, record.getAiUsed());
-                stmt.setString(12, record.getSearchEngine());
-                stmt.setString(13, record.getFiltersApplied());
-                stmt.setString(14, record.getTimestamp());
-                stmt.setString(15, record.getDomainCountry());
+                stmt.setString(5, record.getDomain());
+                stmt.setString(6, record.getSnippet());
+                stmt.setString(7, record.getIsExactMatch());
+                stmt.setString(8, record.getAiVerified());
+                stmt.setString(9, record.getSuccess());
+                stmt.setString(10, record.getTotalResults());
+                stmt.setString(11, record.getProcessingTimeMs());
+                stmt.setString(12, record.getAiUsed());
+                stmt.setString(13, record.getSearchEngine());
+                stmt.setString(14, record.getFiltersApplied());
+                stmt.setString(15, record.getTimestamp());
+                stmt.setString(16, record.getDomainCountry());
 
                 stmt.executeUpdate();
             } catch (SQLIntegrityConstraintViolationException ex) {

--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
@@ -207,6 +207,7 @@ public class Main {
             } else {
                 url = "";
             }
+            final String domain = getDomain(url);
             final String domainCountry = getDomainCountry(url);
             final String snippet = item.containsKey("snippet") ? item.getString("snippet") : "";
             final String isExact;
@@ -228,6 +229,7 @@ public class Main {
             System.out.println("Author: " + author);
             System.out.println("Title: " + title);
             System.out.println("URL: " + url);
+            System.out.println("Domain: " + domain);
             System.out.println("Domain Country: " + domainCountry);
             System.out.println("Snippet: " + snippet);
             System.out.println("Is Exact Match: " + isExact);
@@ -246,6 +248,7 @@ public class Main {
                     author,
                     title,
                     url,
+                    domain,
                     snippet,
                     isExact,
                     aiVerified,
@@ -261,7 +264,7 @@ public class Main {
         }
     }
 
-    private static String getDomainCountry(final String url) {
+    static String getDomain(final String url) {
         if (url == null || url.length() == 0) {
             return "";
         }
@@ -279,6 +282,15 @@ public class Main {
         final int colonIdx = host.indexOf(':');
         if (colonIdx >= 0) {
             host = host.substring(0, colonIdx);
+        }
+        assert host.length() > 0 : "Host part is empty for URL: " + url;
+        return host;
+    }
+
+    static String getDomainCountry(final String url) {
+        final String host = getDomain(url);
+        if (host.length() == 0) {
+            return "";
         }
         final int dotIdx = host.lastIndexOf('.');
         if (dotIdx < 0 || dotIdx >= host.length() - 1) {

--- a/src/test/java/bc/bfi/chatgpt_authors_books_finder/BaseTest.java
+++ b/src/test/java/bc/bfi/chatgpt_authors_books_finder/BaseTest.java
@@ -1,0 +1,49 @@
+package bc.bfi.chatgpt_authors_books_finder;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.anyString;
+
+public class BaseTest {
+
+    @Test
+    public void addSetsDomainParameter() throws SQLException {
+        // Initialization.
+        final AuthorRecord record = new AuthorRecord(
+                "1",
+                "Author",
+                "Title",
+                "http://example.com",
+                "example.com",
+                "Snippet",
+                "true",
+                "true",
+                "1",
+                "10",
+                "false",
+                "engine",
+                "filter",
+                "time",
+                "US");
+        final Connection connection = mock(Connection.class);
+        final PreparedStatement stmt = mock(PreparedStatement.class);
+        when(connection.isClosed()).thenReturn(false);
+        when(connection.prepareStatement(anyString())).thenReturn(stmt);
+
+        // Execution.
+        final Base base = new Base(connection);
+        base.add(record);
+
+        // Assertion.
+        verify(stmt).setString(5, record.getDomain());
+        assertThat(record.getDomain(), is("example.com"));
+    }
+}

--- a/src/test/java/bc/bfi/chatgpt_authors_books_finder/MainTest.java
+++ b/src/test/java/bc/bfi/chatgpt_authors_books_finder/MainTest.java
@@ -1,0 +1,21 @@
+package bc.bfi.chatgpt_authors_books_finder;
+
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class MainTest {
+
+    @Test
+    public void getDomainExtractsHost() {
+        // Initialization.
+        final String url = "https://example.com/path";
+        final String expected = "example.com";
+
+        // Execution.
+        final String domain = Main.getDomain(url);
+
+        // Assertion.
+        assertThat(domain, is(expected));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract domain from each result URL and print it alongside domain country.
- Persist domain field to database via AuthorRecord and Base.
- Add unit tests covering domain extraction and persistence logic.

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68bf99509cf8832bac54c6d21be424f0