### PR TITLE
Align Base.add insert with new schema

### DIFF
--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Base.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Base.java
@@ -58,7 +58,7 @@ public class Base {
             connect();
 
             final String sql = "INSERT INTO " + DB_TABLE
-                    + "(position, author, title, url, domain, snippet, is_exact_match, ai_verified, success, total_results, processing_time_ms, ai_used, search_engine, filters_applied, timestamp, domain_country)"
+                    + "(position, author, title, url, snippet, is_exact_match, ai_verified, success, total_results, processing_time_ms, ai_used, search_engine, filters_applied, timestamp, domain_country, domain)"
                     + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
             try (PreparedStatement stmt = connection.prepareStatement(sql)) {
@@ -66,18 +66,18 @@ public class Base {
                 stmt.setString(2, record.getAuthor());
                 stmt.setString(3, record.getTitle());
                 stmt.setString(4, record.getUrl());
-                stmt.setString(5, record.getDomain());
-                stmt.setString(6, record.getSnippet());
-                stmt.setString(7, record.getIsExactMatch());
-                stmt.setString(8, record.getAiVerified());
-                stmt.setString(9, record.getSuccess());
-                stmt.setString(10, record.getTotalResults());
-                stmt.setString(11, record.getProcessingTimeMs());
-                stmt.setString(12, record.getAiUsed());
-                stmt.setString(13, record.getSearchEngine());
-                stmt.setString(14, record.getFiltersApplied());
-                stmt.setString(15, record.getTimestamp());
-                stmt.setString(16, record.getDomainCountry());
+                stmt.setString(5, record.getSnippet());
+                stmt.setString(6, record.getIsExactMatch());
+                stmt.setString(7, record.getAiVerified());
+                stmt.setString(8, record.getSuccess());
+                stmt.setString(9, record.getTotalResults());
+                stmt.setString(10, record.getProcessingTimeMs());
+                stmt.setString(11, record.getAiUsed());
+                stmt.setString(12, record.getSearchEngine());
+                stmt.setString(13, record.getFiltersApplied());
+                stmt.setString(14, record.getTimestamp());
+                stmt.setString(15, record.getDomainCountry());
+                stmt.setString(16, record.getDomain());
 
                 stmt.executeUpdate();
             } catch (SQLIntegrityConstraintViolationException ex) {

--- a/src/test/java/bc/bfi/chatgpt_authors_books_finder/BaseTest.java
+++ b/src/test/java/bc/bfi/chatgpt_authors_books_finder/BaseTest.java
@@ -43,7 +43,8 @@ public class BaseTest {
         base.add(record);
 
         // Assertion.
-        verify(stmt).setString(5, record.getDomain());
+        verify(stmt).setString(5, record.getSnippet());
+        verify(stmt).setString(16, record.getDomain());
         assertThat(record.getDomain(), is("example.com"));
     }
 }


### PR DESCRIPTION
## Summary
- reorder insert fields in Base.add to skip auto ID and created_at
- extend Base.add unit test verifying snippet and domain parameter positions

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68c4a5adae48832bad0321736e373613