### PR TITLE
Centralize configuration settings

### DIFF
--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Base.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Base.java
@@ -11,16 +11,6 @@ import java.util.Objects;
 
 public class Base {
 
-    static final String DB_HOST = "3.17.216.88";
-    static final int DB_PORT = 3306;
-    static final String DB_NAME = "chatgpt_authors_books_finder";
-    static final String DB_USER = "root";
-    static final String DB_PASSWORD = "RootSecret1!";
-    static final String DB_TABLE = "authors";
-
-    private static final String DB_URL
-            = "jdbc:mysql://" + DB_HOST + ":" + DB_PORT + "/" + DB_NAME;
-
     private static final Logger LOGGER = Logger.getLogger(Base.class.getName());
 
     private Connection connection;
@@ -37,7 +27,10 @@ public class Base {
 
     void connect() throws SQLException {
         if (connection == null || connection.isClosed()) {
-            connection = DriverManager.getConnection(DB_URL, DB_USER, DB_PASSWORD);
+            connection = DriverManager.getConnection(
+                    Config.DB_URL,
+                    Config.DB_USER,
+                    Config.DB_PASSWORD);
         }
     }
 
@@ -57,7 +50,7 @@ public class Base {
         try {
             connect();
 
-            final String sql = "INSERT INTO " + DB_TABLE
+            final String sql = "INSERT INTO " + Config.DB_TABLE
                     + "(position, author, title, url, snippet, is_exact_match, ai_verified, success, total_results, processing_time_ms, ai_used, search_engine, filters_applied, timestamp, domain_country, domain)"
                     + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
@@ -96,7 +89,7 @@ public class Base {
         try {
             connect();
 
-            String sql = "SELECT 1 FROM " + DB_TABLE + " WHERE url = ? LIMIT 1";
+            String sql = "SELECT 1 FROM " + Config.DB_TABLE + " WHERE url = ? LIMIT 1";
             try (PreparedStatement stmt = connection.prepareStatement(sql)) {
                 stmt.setString(1, url);
 

--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Config.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Config.java
@@ -1,0 +1,19 @@
+package bc.bfi.chatgpt_authors_books_finder;
+
+public final class Config {
+
+    public static final String DB_HOST = "3.17.216.88";
+    public static final int DB_PORT = 3306;
+    public static final String DB_NAME = "chatgpt_authors_books_finder";
+    public static final String DB_USER = "root";
+    public static final String DB_PASSWORD = "RootSecret1!";
+    public static final String DB_TABLE = "authors";
+    public static final String DB_URL =
+            "jdbc:mysql://" + DB_HOST + ":" + DB_PORT + "/" + DB_NAME;
+
+    public static final String SERVICE_BASE_URL_ENV = "SERVICE_BASE_URL";
+    public static final String BASE_URL = "http://localhost:8080";
+
+    private Config() {
+    }
+}

--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
@@ -43,12 +43,12 @@ public class Main {
             return;
         }
 
-        final String baseUrlEnv = System.getenv("SERVICE_BASE_URL");
+        final String baseUrlEnv = System.getenv(Config.SERVICE_BASE_URL_ENV);
         final String baseUrl;
         if (baseUrlEnv != null && baseUrlEnv.length() > 0) {
             baseUrl = baseUrlEnv;
         } else {
-            baseUrl = "http://localhost:8080";
+            baseUrl = Config.BASE_URL;
         }
 
         final Base base = new Base();

--- a/src/test/java/bc/bfi/chatgpt_authors_books_finder/ConfigTest.java
+++ b/src/test/java/bc/bfi/chatgpt_authors_books_finder/ConfigTest.java
@@ -1,0 +1,20 @@
+package bc.bfi.chatgpt_authors_books_finder;
+
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class ConfigTest {
+
+    @Test
+    public void dbUrlIsConstructedProperly() {
+        // Initialization.
+        final String expected = "jdbc:mysql://3.17.216.88:3306/chatgpt_authors_books_finder";
+
+        // Execution.
+        final String url = Config.DB_URL;
+
+        // Assertion.
+        assertThat(url, is(expected));
+    }
+}


### PR DESCRIPTION
## Summary
- add Config class housing database and service constants
- refactor Base and Main to use Config constants
- cover Config with unit test for DB URL construction

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68c4a8c0539c832b8605f39595e2ae58