### PR TITLE
Use new API search endpoint for author lookup

### DIFF
--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Config.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Config.java
@@ -13,6 +13,7 @@ public final class Config {
 
     public static final String SERVICE_BASE_URL_ENV = "SERVICE_BASE_URL";
     public static final String BASE_URL = "http://localhost:8080";
+    public static final String API_KEY = "ask_live_7f9d2e1a4b8c6f3e9d2c5a8b7e4f1a9c";
 
     private Config() {
     }

--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
@@ -5,7 +5,6 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringReader;
-import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -20,13 +19,10 @@ import javax.json.JsonObject;
 import javax.json.JsonReader;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 
-import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.apache.hc.core5.http.io.entity.StringEntity;
 
 public class Main {
 
@@ -110,11 +106,13 @@ public class Main {
 
         final CloseableHttpClient client = HttpClients.createDefault();
         try {
-            final HttpGet get = new HttpGet(baseUrl + "/api-playground.php/" + URLEncoder.encode(author, StandardCharsets.UTF_8.toString()));
-//            final HttpPost post = new HttpPost(baseUrl + "/api-playground.php");
-//            final String json = "{\"author\":\"" + author.replace("\"", "\\\"") + "\"}";
-//            final StringEntity entity = new StringEntity(json, ContentType.APPLICATION_JSON);
-//            post.setEntity(entity);
+            final String encodedAuthor = URLEncoder.encode(author, StandardCharsets.UTF_8.toString());
+            final HttpGet get = new HttpGet(baseUrl + "/api-search.php/" + encodedAuthor);
+            get.setHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:143.0) Gecko/20100101 Firefox/143.0");
+            get.setHeader("Accept", "*/*");
+            get.setHeader("Accept-Language", "en-US,en;q=0.5");
+            get.setHeader("Referer", baseUrl + "/api-playground.php");
+            get.setHeader("X-API-Key", Config.API_KEY);
             final CloseableHttpResponse response = client.execute(get);
             try {
                 final int status = response.getCode();


### PR DESCRIPTION
## Summary
- add the provided API key to the configuration for reuse
- call the api-search endpoint when looking up authors and include the required headers

## Testing
- mvn -q test *(fails: network is unreachable when downloading Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_b_68cb0aabbde8832b9d145527056ad8a9