### PR TITLE
Switch Base persistence to PostgreSQL

### DIFF
--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Config.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Config.java
@@ -10,6 +10,10 @@ public final class Config {
     static final String DB_USERNAME = "redash";
     static final String DB_PASSWORD = "te83NECug38ueP";
     static final String DB_DATABASE = "scrapers";
+    static final String DB_URL = "jdbc:postgresql://"
+            + DB_HOST + ":"
+            + DB_PORT + "/"
+            + DB_DATABASE;
     static final String DB_TABLE = "chatgpt_websites_finder.chatgpt_authors";
 
     public static final String SERVICE_BASE_URL_ENV = "SERVICE_BASE_URL";

--- a/src/test/java/bc/bfi/chatgpt_authors_books_finder/ConfigTest.java
+++ b/src/test/java/bc/bfi/chatgpt_authors_books_finder/ConfigTest.java
@@ -9,7 +9,7 @@ public class ConfigTest {
     @Test
     public void dbUrlIsConstructedProperly() {
         // Initialization.
-        final String expected = "jdbc:mysql://3.17.216.88:3306/chatgpt_authors_books_finder";
+        final String expected = "jdbc:postgresql://3.140.167.34:5432/scrapers";
 
         // Execution.
         final String url = Config.DB_URL;


### PR DESCRIPTION
## Summary
- update the Base class to connect with PostgreSQL credentials and log duplicate inserts using SQL state checks
- expose the PostgreSQL JDBC URL in the configuration and align the unit test expectation with the new connection string

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_b_68e3cbc7c8dc832bb72e0c93cce48890