### PR TITLE
Load authors to scrape from PostgreSQL view

### DIFF
--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Config.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Config.java
@@ -10,10 +10,6 @@ public final class Config {
     static final String DB_USERNAME = "redash";
     static final String DB_PASSWORD = "te83NECug38ueP";
     static final String DB_DATABASE = "scrapers";
-    static final String DB_URL = "jdbc:postgresql://"
-            + DB_HOST + ":"
-            + DB_PORT + "/"
-            + DB_DATABASE;
     static final String DB_TABLE = "chatgpt_websites_finder.chatgpt_authors";
     static final String DB_URL = buildDbUrl();
     static final String DB_USER = DB_USERNAME;

--- a/src/test/java/bc/bfi/chatgpt_authors_books_finder/MainTest.java
+++ b/src/test/java/bc/bfi/chatgpt_authors_books_finder/MainTest.java
@@ -1,5 +1,8 @@
 package bc.bfi.chatgpt_authors_books_finder;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -17,5 +20,32 @@ public class MainTest {
 
         // Assertion.
         assertThat(domain, is(expected));
+    }
+
+    @Test
+    public void addAuthorIfValidTrimsAndAppendsValue() {
+        // Initialization.
+        final List<String> authors = new ArrayList<String>();
+        final String value = "  Jane Austen  ";
+
+        // Execution.
+        Main.addAuthorIfValid(authors, value);
+
+        // Assertion.
+        assertThat(authors.size(), is(1));
+        assertThat(authors.get(0), is("Jane Austen"));
+    }
+
+    @Test
+    public void addAuthorIfValidSkipsBlankValues() {
+        // Initialization.
+        final List<String> authors = new ArrayList<String>();
+        final String value = "   ";
+
+        // Execution.
+        Main.addAuthorIfValid(authors, value);
+
+        // Assertion.
+        assertThat(authors.size(), is(0));
     }
 }


### PR DESCRIPTION
## Summary
- fetch authors to process from the PostgreSQL view instead of the text file
- add validation helper so blank author names are skipped and covered it with unit tests
- remove the duplicate DB URL constant definition in the configuration

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_b_68e3d5be364c832b826b62b8cb8846e3