### PR TITLE
Persist authors with empty search results

### DIFF
--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
@@ -172,7 +172,7 @@ public class Main {
         }
     }
 
-    private static void handleAuthorResult(final String author, final JsonObject data, final Base base) {
+    static void handleAuthorResult(final String author, final JsonObject data, final Base base) {
         Objects.requireNonNull(author, "author");
         Objects.requireNonNull(data, "data");
         Objects.requireNonNull(base, "base");
@@ -182,11 +182,6 @@ public class Main {
             results = data.getJsonArray("results");
         } else {
             results = Json.createArrayBuilder().build();
-        }
-
-        if (results.size() == 0) {
-            System.out.println("No results for " + author);
-            return;
         }
 
         final boolean success = data.containsKey("success") && data.getBoolean("success");
@@ -230,6 +225,30 @@ public class Main {
             searchEngine = "";
             filtersApplied = "";
             timestamp = "";
+        }
+
+        if (results.size() == 0) {
+            System.out.println("No results for " + author);
+
+            final AuthorRecord record = new AuthorRecord(
+                    "0",
+                    author,
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    String.valueOf(success),
+                    String.valueOf(totalResults),
+                    String.valueOf(processingTime),
+                    String.valueOf(aiUsed),
+                    searchEngine,
+                    filtersApplied,
+                    timestamp,
+                    "");
+            base.add(record);
+            return;
         }
 
         for (int i = 0; i < results.size(); i++) {

--- a/src/test/java/bc/bfi/chatgpt_authors_books_finder/MainTest.java
+++ b/src/test/java/bc/bfi/chatgpt_authors_books_finder/MainTest.java
@@ -3,7 +3,13 @@ package bc.bfi.chatgpt_authors_books_finder;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.json.Json;
+import javax.json.JsonObject;
+
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -47,5 +53,35 @@ public class MainTest {
 
         // Assertion.
         assertThat(authors.size(), is(0));
+    }
+
+    @Test
+    public void handleAuthorResultStoresEmptySearches() {
+        // Initialization.
+        final String author = "Unknown Writer";
+        final JsonObject data = Json.createObjectBuilder()
+                .add("results", Json.createArrayBuilder().build())
+                .add("success", false)
+                .add("total_results", 0)
+                .add("processing_time_ms", 0)
+                .add("ai_analysis_used", false)
+                .add("metadata", Json.createObjectBuilder()
+                        .add("search_engine", "bing")
+                        .add("filters_applied", Json.createArrayBuilder())
+                        .add("timestamp", "2024-01-01T00:00:00Z")
+                        .build())
+                .build();
+        final Base base = Mockito.mock(Base.class);
+        final ArgumentCaptor<AuthorRecord> captor = ArgumentCaptor.forClass(AuthorRecord.class);
+
+        // Execution.
+        Main.handleAuthorResult(author, data, base);
+
+        // Assertion.
+        Mockito.verify(base).add(captor.capture());
+        final AuthorRecord record = captor.getValue();
+        assertThat(record.getAuthor(), is(author));
+        assertThat(record.getPosition(), is("0"));
+        assertThat(record.getTitle(), is(""));
     }
 }


### PR DESCRIPTION
## Summary
- store a placeholder record with position 0 when an author search returns no results
- allow tests to invoke handleAuthorResult and verify that Base.add receives the fallback record

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_b_68e3da94b4c4832b8e5248a48cab51fa