### PR TITLE
Preserve contact page URL without detected form

### DIFF
--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/ContactFormDetector.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/ContactFormDetector.java
@@ -1,0 +1,67 @@
+package bc.bfi.chatgpt_authors_books_finder;
+
+import java.util.Locale;
+import java.util.Objects;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+public class ContactFormDetector {
+
+    public boolean hasContactForm(final String html) {
+        if (html == null) {
+            return false;
+        }
+        final String trimmed = html.trim();
+        if (trimmed.length() == 0) {
+            return false;
+        }
+        final Document document = Jsoup.parse(trimmed);
+        final Elements forms = document.getElementsByTag("form");
+        for (int i = 0; i < forms.size(); i++) {
+            final Element form = forms.get(i);
+            if (containsContactKeyword(form.id())) {
+                return true;
+            }
+            if (containsContactKeyword(form.attr("name"))) {
+                return true;
+            }
+            if (containsContactKeyword(form.attr("class"))) {
+                return true;
+            }
+            if (containsContactKeyword(form.attr("action"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void updateWebsiteContactInfo(
+            final Website website,
+            final String contactPageUrl,
+            final String contactPageHtml) {
+        Objects.requireNonNull(website, "website");
+
+        if (contactPageUrl == null) {
+            return;
+        }
+        final String trimmedUrl = contactPageUrl.trim();
+        if (trimmedUrl.length() == 0) {
+            return;
+        }
+
+        website.setContactPageUrl(trimmedUrl);
+        final boolean found = hasContactForm(contactPageHtml);
+        website.setContactFormFound(found);
+    }
+
+    private boolean containsContactKeyword(final String value) {
+        if (value == null) {
+            return false;
+        }
+        final String lower = value.toLowerCase(Locale.ENGLISH);
+        return lower.contains("contact");
+    }
+}

--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
@@ -358,4 +358,15 @@ public class Main {
         }
         return "";
     }
+
+    static void processContactPage(
+            final Website website,
+            final String contactPageUrl,
+            final String contactPageHtml,
+            final ContactFormDetector detector) {
+        Objects.requireNonNull(website, "website");
+        Objects.requireNonNull(detector, "detector");
+
+        detector.updateWebsiteContactInfo(website, contactPageUrl, contactPageHtml);
+    }
 }

--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Website.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Website.java
@@ -1,0 +1,37 @@
+package bc.bfi.chatgpt_authors_books_finder;
+
+import java.util.Objects;
+
+public class Website {
+
+    private final String url;
+    private String contactPageUrl;
+    private boolean contactFormFound;
+
+    public Website(final String url) {
+        this.url = Objects.requireNonNull(url, "url");
+        this.contactPageUrl = "";
+        this.contactFormFound = false;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getContactPageUrl() {
+        return contactPageUrl;
+    }
+
+    public void setContactPageUrl(final String contactPageUrl) {
+        Objects.requireNonNull(contactPageUrl, "contactPageUrl");
+        this.contactPageUrl = contactPageUrl;
+    }
+
+    public boolean isContactFormFound() {
+        return contactFormFound;
+    }
+
+    public void setContactFormFound(final boolean contactFormFound) {
+        this.contactFormFound = contactFormFound;
+    }
+}

--- a/src/test/java/bc/bfi/chatgpt_authors_books_finder/ContactFormDetectorTest.java
+++ b/src/test/java/bc/bfi/chatgpt_authors_books_finder/ContactFormDetectorTest.java
@@ -1,0 +1,41 @@
+package bc.bfi.chatgpt_authors_books_finder;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class ContactFormDetectorTest {
+
+    @Test
+    public void updateWebsiteContactInfoKeepsUrlWhenFormMissing() {
+        // Initialization.
+        final ContactFormDetector detector = new ContactFormDetector();
+        final Website website = new Website("https://example.com");
+        final String contactUrl = "https://example.com/contact";
+        final String html = "<html><body><h1>Contact us</h1></body></html>";
+
+        // Execution.
+        detector.updateWebsiteContactInfo(website, contactUrl, html);
+
+        // Assertion.
+        assertThat(website.getContactPageUrl(), is(contactUrl));
+        assertThat(website.isContactFormFound(), is(false));
+    }
+
+    @Test
+    public void updateWebsiteContactInfoMarksFormWhenFound() {
+        // Initialization.
+        final ContactFormDetector detector = new ContactFormDetector();
+        final Website website = new Website("https://example.com");
+        final String contactUrl = "https://example.com/contact";
+        final String html = "<html><body><form id=\"contact-form\"></form></body></html>";
+
+        // Execution.
+        detector.updateWebsiteContactInfo(website, contactUrl, html);
+
+        // Assertion.
+        assertThat(website.getContactPageUrl(), is(contactUrl));
+        assertThat(website.isContactFormFound(), is(true));
+    }
+}

--- a/src/test/java/bc/bfi/chatgpt_authors_books_finder/MainTest.java
+++ b/src/test/java/bc/bfi/chatgpt_authors_books_finder/MainTest.java
@@ -84,4 +84,19 @@ public class MainTest {
         assertThat(record.getPosition(), is("0"));
         assertThat(record.getTitle(), is(""));
     }
+
+    @Test
+    public void processContactPageDelegatesToDetector() {
+        // Initialization.
+        final Website website = new Website("https://example.com");
+        final ContactFormDetector detector = Mockito.mock(ContactFormDetector.class);
+        final String contactUrl = "https://example.com/contact";
+        final String html = "<html></html>";
+
+        // Execution.
+        Main.processContactPage(website, contactUrl, html, detector);
+
+        // Assertion.
+        Mockito.verify(detector).updateWebsiteContactInfo(website, contactUrl, html);
+    }
 }


### PR DESCRIPTION
## Summary
- add a ContactFormDetector that leaves the contact page URL intact when no form markup is found
- introduce a Website data holder and wire Main through the detector to manage contact pages
- cover the detector behaviour and Main delegation with new unit tests

## Testing
- mvn -q test

------
https://chatgpt.com/codex/tasks/task_b_68e505d21668832b9025e49dd5d4e058