### PR TITLE
Support test mode author loading

### DIFF
--- a/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
+++ b/src/main/java/bc/bfi/chatgpt_authors_books_finder/Main.java
@@ -1,5 +1,7 @@
 package bc.bfi.chatgpt_authors_books_finder;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.URLEncoder;
@@ -40,7 +42,7 @@ public class Main {
     }
 
     public static void main(final String[] args) {
-        final List<String> authors = readAuthorsFromDatabase();
+        final List<String> authors = readAuthors();
         if (authors.isEmpty()) {
             System.out.println("No authors to process.");
             return;
@@ -70,6 +72,13 @@ public class Main {
         } finally {
             base.close();
         }
+    }
+
+    static List<String> readAuthors() {
+        if (Boolean.TRUE.equals(Config.isTestMode)) {
+            return readAuthorsFromFile();
+        }
+        return readAuthorsFromDatabase();
     }
 
     private static List<String> readAuthorsFromDatabase() {
@@ -109,6 +118,32 @@ public class Main {
                 try {
                     connection.close();
                 } catch (SQLException ignore) {
+                    // ignore
+                }
+            }
+        }
+
+        return authors;
+    }
+
+    private static List<String> readAuthorsFromFile() {
+        final List<String> authors = new ArrayList<String>();
+        BufferedReader reader = null;
+
+        try {
+            reader = new BufferedReader(new FileReader(Config.FILE_WITH_TEST_AUTHORS));
+            String line = reader.readLine();
+            while (line != null) {
+                addAuthorIfValid(authors, line);
+                line = reader.readLine();
+            }
+        } catch (IOException ex) {
+            System.out.println("Failed to load authors from file: " + ex.getMessage());
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (IOException ignore) {
                     // ignore
                 }
             }

--- a/src/test/java/bc/bfi/chatgpt_authors_books_finder/MainTest.java
+++ b/src/test/java/bc/bfi/chatgpt_authors_books_finder/MainTest.java
@@ -11,6 +11,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 
 public class MainTest {
@@ -83,5 +84,20 @@ public class MainTest {
         assertThat(record.getAuthor(), is(author));
         assertThat(record.getPosition(), is("0"));
         assertThat(record.getTitle(), is(""));
+    }
+
+    @Test
+    public void readAuthorsUsesTestFileInTestMode() {
+        // Initialization.
+        final String expectedFirstAuthor = "\"Achim Schade, Matthias Redieck\"";
+        final String expectedAuthor = "98 Degrees";
+
+        // Execution.
+        final List<String> authors = Main.readAuthors();
+
+        // Assertion.
+        assertThat("Authors list should not be empty", authors.isEmpty(), is(false));
+        assertThat(authors.get(0), is(expectedFirstAuthor));
+        assertThat(authors, hasItem(expectedAuthor));
     }
 }


### PR DESCRIPTION
## Summary
- add a helper to load authors from the configured test file when test mode is enabled
- keep the existing database reader for production mode and reuse it through the new helper
- cover the new behavior with a unit test that asserts file contents are returned in test mode

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_b_68f1057030a4832b8090d6de15c1220f